### PR TITLE
:white_check_mark: Internal Mag check

### DIFF
--- a/SDK Extras/Editor/GunValidation.cs
+++ b/SDK Extras/Editor/GunValidation.cs
@@ -75,6 +75,12 @@ public class GunValidation {
             Success = () => gameObject.GetComponent<Gun>()?.defaultMagazine ?? gameObject.GetComponent<Gun>()?.internalMagazine != null
         });
 
+        results.Add(new ValidationResult
+        {
+            Testcase = "If you are not doing an infinite ammo type of gun Internal Magazine should be set as none to prevent reloading issue",
+            Success = () => gameObject.GetComponent<Gun>()?.internalMagazine == null
+        });
+
         results.AddRange(SharedValidation.SharedValidationRules());
 
         ValidationResult.DisplayResults(results);

--- a/SDK Extras/Editor/GunValidation.cs
+++ b/SDK Extras/Editor/GunValidation.cs
@@ -78,7 +78,17 @@ public class GunValidation {
         results.Add(new ValidationResult
         {
             Testcase = "If you are not doing an infinite ammo type of gun Internal Magazine should be set as none to prevent reloading issue",
-            Success = () => gameObject.GetComponent<Gun>()?.internalMagazine == null
+            Success = () => {
+                var internalMag = gameObject.GetComponent<Gun>()?.internalMagazine;
+                var defaultMagRound = gameObject.GetComponent<Gun>()?.defaultMagazine.rounds;
+                return internalMag == null && defaultMagRound != 999999;
+            }
+        });
+
+        results.Add(new ValidationResult
+        {
+            Testcase = "Shoulder Transform shouldn't be null",
+            Success = () => gameObject.GetComponent<HandgunVirtualController>()?.shoulderTransform != null
         });
 
         results.AddRange(SharedValidation.SharedValidationRules());


### PR DESCRIPTION
Add testcase to check Internal Magazine to prevent reloading issue.

Some modders have experimented issue when setting an Internal Magazine in the gun script.
Basically ejecting the internal mag is impossible so it does for replacing with a new mag.

I need to do extensive tests to check if I can conditionnally do this test in order to be sure that setting internal mag is only for infinite ammo type of gun. If I'll realise it is I'll check in the test if default magazine is set.

But concidering most modders are actually working on guns with exchange magazine system I think this test is still relevant as it is for now.