### PR TITLE
Fixed namespace declaration inside of SpawnFragment and SpawnFragmentArray script

### DIFF
--- a/SDK Extras/Assembly-CSharp/SLZ/ExtendedPrefabSpawner.cs
+++ b/SDK Extras/Assembly-CSharp/SLZ/ExtendedPrefabSpawner.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 using SLZ.Marrow.Data;
 using UnityEngine;
 
-namespace SLZ
+namespace SLZ.Utilities
 {
 	public class ExtendedPrefabSpawner : MonoBehaviour
 	{

--- a/SDK Extras/Assembly-CSharp/SLZ/ExtendedPrefabSpawner.cs
+++ b/SDK Extras/Assembly-CSharp/SLZ/ExtendedPrefabSpawner.cs
@@ -39,6 +39,12 @@ namespace SLZ.Utilities
 		public Vector3 spawnTorqueHigh;
 
 		public float frequencey;
+  
+  		public bool useCoolDown;
+
+		public bool useRestCoolDown;
+
+		public UnityEvent spawnEvent;
 
 		private Rigidbody rb;
 

--- a/SDK Extras/Assembly-CSharp/SLZ/SpawnFragment.cs
+++ b/SDK Extras/Assembly-CSharp/SLZ/SpawnFragment.cs
@@ -3,7 +3,7 @@ using SLZ.Marrow.Utilities;
 using SLZ.SFX;
 using UnityEngine;
 
-namespace SLZ
+namespace SLZ.Props
 {
 	public class SpawnFragment : MonoBehaviour
 	{

--- a/SDK Extras/Assembly-CSharp/SLZ/SpawnFragmentArray.cs
+++ b/SDK Extras/Assembly-CSharp/SLZ/SpawnFragmentArray.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 using SLZ.Marrow.Data;
 using UnityEngine;
 
-namespace SLZ
+namespace SLZ.Props
 {
 	public class SpawnFragmentArray : MonoBehaviour
 	{


### PR DESCRIPTION
I noticed that neither the SpawnFragment nor the SpawnFragmentArray script was compiling into my BONELAB maps, so I looked into the name of the script inside of BONELAB with UnityExplorer and noticed that the namespace inside of the extended SDK was wrong. 

After fixing this, the script loads into modded maps without problems.

Update: exact same thing happened to the ExtendedPrefabSpawner script. The erroneous namespace declaration prevents this script from compiling into the game. Fixed with this pull request as well.

Update No. 2: I have also noticed while playing around with the ExtendedPrefabSpawner script that there are at least 3 properties that are missing from this extended SDK. I have added them and can confirm that they work flawlessly in-game.